### PR TITLE
fix(vue integration type): component name is now optional

### DIFF
--- a/build/src/base/event/addons/index.d.ts
+++ b/build/src/base/event/addons/index.d.ts
@@ -7,5 +7,5 @@ import { DefaultAddons } from './default';
 /**
  * Union Type describing all catcher-specific additional data
  */
-declare type EventAddons = JavaScriptAddons | PhpAddons | NodeJSAddons | GoAddons | PythonAddons | DefaultAddons;
-export { WindowData, VueIntegrationAddons, BeautifiedUserAgent, EventAddons, JavaScriptAddons, PhpAddons, NodeJSAddons, GoAddons, PythonAddons, DefaultAddons };
+declare type EventAddons = DefaultAddons | JavaScriptAddons | PhpAddons | NodeJSAddons | GoAddons | PythonAddons | DefaultAddons;
+export { WindowData, VueIntegrationAddons, BeautifiedUserAgent, EventAddons, DefaultAddons, JavaScriptAddons, PhpAddons, NodeJSAddons, GoAddons, PythonAddons, };

--- a/build/src/base/event/addons/javascript.d.ts
+++ b/build/src/base/event/addons/javascript.d.ts
@@ -77,7 +77,7 @@ export interface VueIntegrationAddons {
     /**
      * Component name where error occurred
      */
-    component: string;
+    component: string | null;
     /**
      * Component props
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/types",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "TypeScript definitions for Hawk",
   "types": "build/index.d.ts",
   "main": "build/index.js",

--- a/src/base/event/addons/index.ts
+++ b/src/base/event/addons/index.ts
@@ -29,5 +29,4 @@ export {
   NodeJSAddons,
   GoAddons,
   PythonAddons,
-  DefaultAddons
 }

--- a/src/base/event/addons/javascript.ts
+++ b/src/base/event/addons/javascript.ts
@@ -92,7 +92,7 @@ export interface VueIntegrationAddons {
   /**
    * Component name where error occurred
    */
-  component: string;
+  component: string | null;
 
   /**
    * Component props


### PR DESCRIPTION
Component can be null when:
- Catcher has not managed to extract component name
- Error thrown not in a component