### PR TITLE
Imp(events): move timestamp out of the payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/types",
-  "version": "0.1.28",
+  "version": "0.1.29-rc1",
   "description": "TypeScript definitions for Hawk",
   "types": "build/index.d.ts",
   "main": "build/index.js",

--- a/src/base/event/event.ts
+++ b/src/base/event/event.ts
@@ -52,16 +52,8 @@ export interface EventData<CatcherAddons extends EventAddons> {
 
 /**
  * Event accepted and processed by Collector.
- * It sets the timestamp to the event payload.
  */
-export interface EventDataAccepted<EventAddons> extends EventData<EventAddons> {
-    /**
-     * Occurrence time
-     * Unix timestamp in seconds (example: 1567009247.576)
-     * (Set by the Collector)
-     */
-    timestamp: number;
-}
+export interface EventDataAccepted<EventAddons> extends EventData<EventAddons> {};
 
 
 /**

--- a/src/dbScheme/groupedEvent.ts
+++ b/src/dbScheme/groupedEvent.ts
@@ -41,6 +41,13 @@ export interface GroupedEventDBScheme {
      * Array of users who visited this event
      */
     visitedBy: UserDBScheme[];
+
+    /**
+     * Occurrence time
+     * Unix timestamp in seconds (example: 1567009247.576)
+     * (Set by the Collector)
+     */
+    timestamp: number;
 }
 
 /**


### PR DESCRIPTION
## Changes
- Now timestamp would be stored for all events and repetitions to avoid overwriting in grouper
- Timestamp moved out of the payload