### PR TITLE
feat: export ConsoleLogEvent type

### DIFF
--- a/build/src/base/event/addons/index.d.ts
+++ b/build/src/base/event/addons/index.d.ts
@@ -1,4 +1,4 @@
-import { JavaScriptAddons, WindowData, VueIntegrationAddons, BeautifiedUserAgent } from './javascript';
+import { JavaScriptAddons, WindowData, VueIntegrationAddons, BeautifiedUserAgent, ConsoleLogEvent } from './javascript';
 import { PhpAddons } from './php';
 import { NodeJSAddons } from './nodejs';
 import { GoAddons } from './go';
@@ -8,4 +8,4 @@ import { DefaultAddons } from './default';
  * Union Type describing all catcher-specific additional data
  */
 declare type EventAddons = DefaultAddons | JavaScriptAddons | PhpAddons | NodeJSAddons | GoAddons | PythonAddons | DefaultAddons;
-export { WindowData, VueIntegrationAddons, BeautifiedUserAgent, EventAddons, DefaultAddons, JavaScriptAddons, PhpAddons, NodeJSAddons, GoAddons, PythonAddons, };
+export { WindowData, VueIntegrationAddons, BeautifiedUserAgent, ConsoleLogEvent, EventAddons, DefaultAddons, JavaScriptAddons, PhpAddons, NodeJSAddons, GoAddons, PythonAddons, };

--- a/build/src/base/event/addons/javascript.d.ts
+++ b/build/src/base/event/addons/javascript.d.ts
@@ -48,6 +48,10 @@ export interface ConsoleLogEvent {
      * File and line number where the log occurred
      */
     fileLine?: string;
+    /**
+     * CSS styles for %c formatting
+     */
+    styles?: string[];
 }
 /**
  * Additional data that can be sent by the JavaScript Catcher

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/types",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "TypeScript definitions for Hawk",
   "types": "build/index.d.ts",
   "main": "build/index.js",

--- a/src/base/event/addons/index.ts
+++ b/src/base/event/addons/index.ts
@@ -1,4 +1,4 @@
-import { JavaScriptAddons, WindowData, VueIntegrationAddons, BeautifiedUserAgent } from './javascript';
+import { JavaScriptAddons, WindowData, VueIntegrationAddons, BeautifiedUserAgent, ConsoleLogEvent } from './javascript';
 import { PhpAddons } from './php';
 import { NodeJSAddons } from './nodejs';
 import { GoAddons } from './go';
@@ -22,6 +22,7 @@ export {
   WindowData,
   VueIntegrationAddons,
   BeautifiedUserAgent,
+  ConsoleLogEvent,
   EventAddons,
   DefaultAddons,
   JavaScriptAddons,

--- a/src/base/event/addons/javascript.ts
+++ b/src/base/event/addons/javascript.ts
@@ -58,6 +58,11 @@ export interface ConsoleLogEvent {
    * File and line number where the log occurred
    */
   fileLine?: string;
+
+  /**
+   * CSS styles for %c formatting
+   */
+  styles?: string[];
 }
 
 /**


### PR DESCRIPTION
Problem: ConsoleLogEvent type is not accessible for external usage
Changes: exported ConsoleLogEvent type from public API