### PR TITLE
Optional count fields added

### DIFF
--- a/build/src/catchers/catcher-message.d.ts
+++ b/build/src/catchers/catcher-message.d.ts
@@ -63,6 +63,11 @@ export interface CatcherMessage<Type extends CatcherMessageType> {
      * All information about the event
      */
     payload: CatcherMessagePayload<Type>;
+    /**
+     * Number of identical occurrences this message represents.
+     * Computed on Catcher side to dedupe similar events caused in the same time.
+     */
+    count?: number;
 }
 /**
  * Type that represents a Catcher message accepted by the collector

--- a/build/src/dbScheme/repetition.d.ts
+++ b/build/src/dbScheme/repetition.d.ts
@@ -29,6 +29,12 @@ export interface RepetitionDBScheme {
      * (created by the Collector)
      */
     timestamp: number;
+    /**
+     * Number of real client-side occurrences merged into this single repetition
+     * by Catcher-side debounce (see CatcherMessage.count).
+     * Absent or 1 — this repetition represents a single occurrence.
+     */
+    count?: number;
 }
 /**
  * Repetition with decoded event data

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/types",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "TypeScript definitions for Hawk",
   "types": "build/index.d.ts",
   "main": "build/index.js",

--- a/src/catchers/catcher-message.ts
+++ b/src/catchers/catcher-message.ts
@@ -83,6 +83,12 @@ export interface CatcherMessage<Type extends CatcherMessageType> {
    * All information about the event
    */
   payload: CatcherMessagePayload<Type>;
+
+  /**
+   * Number of identical occurrences this message represents.
+   * Computed on Catcher side to dedupe similar events caused in the same time.
+   */
+  count?: number;
 }
 
 /**

--- a/src/dbScheme/repetition.ts
+++ b/src/dbScheme/repetition.ts
@@ -34,6 +34,13 @@ export interface RepetitionDBScheme {
    * (created by the Collector)
    */
   timestamp: number;
+
+  /**
+   * Number of real client-side occurrences merged into this single repetition
+   * by Catcher-side debounce (see CatcherMessage.count).
+   * Absent or 1 — this repetition represents a single occurrence.
+   */
+  count?: number;
 }
 
 /**


### PR DESCRIPTION
Adds an optional `count` field used by the client-side debounce feature to merge
repeated occurrences of the same error within a short time window into a single
network message, while still tracking how many real occurrences it represents.

- `CatcherMessage.count` — set by Catcher SDK on the message sent to Collector
- `RepetitionDBScheme.count` — set by the grouper worker on the stored repetition,
  carrying the same number through to API/Garage

Both fields are optional; absent or `1` means a single occurrence — no behavior
change for clients/data that don't use debounce.