### PR TITLE
feat(ai): add AI stream types

### DIFF
--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -1,3 +1,4 @@
+export * from './src/ai/stream';
 export * from './src/auth/tokensPair';
 export * from './src/base/businessOperation/businessOperation';
 export * from './src/billing/planProlongrationPayload';

--- a/build/index.js
+++ b/build/index.js
@@ -14,6 +14,7 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./src/ai/stream"), exports);
 __exportStar(require("./src/auth/tokensPair"), exports);
 __exportStar(require("./src/base/businessOperation/businessOperation"), exports);
 __exportStar(require("./src/billing/planProlongrationPayload"), exports);

--- a/build/src/ai/stream.d.ts
+++ b/build/src/ai/stream.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Stream part that carries generated text.
+ */
+export type AiStreamTextDeltaPart = {
+    /**
+     * Discriminant of a text-carrying part.
+     */
+    type: 'text-delta';
+    /**
+     * Text generated for this part.
+     */
+    delta: string;
+};
+/**
+ * Stream part that carries a generation failure.
+ */
+export type AiStreamErrorPart = {
+    /**
+     * Discriminant of a failure-carrying part.
+     */
+    type: 'error';
+    /**
+     * Description of the failure.
+     */
+    errorText: string;
+};
+/**
+ * Discriminated union of parts an AI stream consists of.
+ */
+export type AiStreamPart = AiStreamTextDeltaPart | AiStreamErrorPart;
+/**
+ * Asynchronous sequence of parts forming an AI-generated answer.
+ */
+export type AiStream = AsyncIterable<AiStreamPart>;

--- a/build/src/ai/stream.js
+++ b/build/src/ai/stream.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,5 @@
+export * from './src/ai/stream';
+
 export * from './src/auth/tokensPair';
 
 export * from './src/base/businessOperation/businessOperation';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hawk.so/types",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "TypeScript definitions for Hawk",
   "types": "build/index.d.ts",
   "main": "build/index.js",

--- a/src/ai/stream.ts
+++ b/src/ai/stream.ts
@@ -1,0 +1,39 @@
+/**
+ * Stream part that carries generated text.
+ */
+export type AiStreamTextDeltaPart = {
+  /**
+   * Discriminant of a text-carrying part.
+   */
+  type: 'text-delta';
+
+  /**
+   * Text generated for this part.
+   */
+  delta: string;
+};
+
+/**
+ * Stream part that carries a generation failure.
+ */
+export type AiStreamErrorPart = {
+  /**
+   * Discriminant of a failure-carrying part.
+   */
+  type: 'error';
+
+  /**
+   * Description of the failure.
+   */
+  errorText: string;
+};
+
+/**
+ * Discriminated union of parts an AI stream consists of.
+ */
+export type AiStreamPart = AiStreamTextDeltaPart | AiStreamErrorPart;
+
+/**
+ * Asynchronous sequence of parts forming an AI-generated answer.
+ */
+export type AiStream = AsyncIterable<AiStreamPart>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', 'ES2022', 'ES2023', 'ES2024', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
`AiStreamPart` carries an answer received by model and converted for further rendering.

Currently it unites following types: `AiStreamTextDeltaPart` (text increments) and `AiStreamErrorPart` (failure description).

`AiStream` carries part sequence asynchronously.

Tsconfig target moves from es6 to es2024 because `AsyncIterable` type is delivered only since es2018.